### PR TITLE
Fix codepage name 'mac-centraleurope' to 'x-mac-ce'

### DIFF
--- a/src/Core/CodepageName.cs
+++ b/src/Core/CodepageName.cs
@@ -338,10 +338,7 @@ namespace UtfUnknown.Core
         /// <summary>
         /// MAC Latin-2 codepage name.
         /// </summary>
-        /// <remarks>
-        /// TODO: Fix to x-mac-ce
-        /// </remarks>
-        internal const string X_MAC_CE = "MAC-CENTRALEUROPE";
+        internal const string X_MAC_CE = "x-mac-ce";
         
         /// <summary>
         /// Cyrillic (Mac) codepage name.

--- a/tests/Data/x-mac-ce/lang_cs_mac-centraleurope.txt
+++ b/tests/Data/x-mac-ce/lang_cs_mac-centraleurope.txt
@@ -1,0 +1,4 @@
+LedË‡‹ek Ş’‹n’ (Alcedo atthis) je prómrn 16,5 cm velkù pt‡k z ‹eledi
+ledË‡‹kovitùch (Alcedinidae). Je velmi vùrazn zbarvenù s oranìovou spodinou a
+modrùm hŞbetem, kŞ’dly a temenem. Vùraznùm znakem je tak jeho n‡padn dlouhù
+zaäpi‹atlù zob‡k. Pro sv kr‡sn zbarven’ je nazùv‡n Ltaj’c’ drahokam.


### PR DESCRIPTION
Resolve #75 and fixes #78 