### PR TITLE
Add support 2-byte arrays for utf with bom

### DIFF
--- a/src/CharsetDetector.cs
+++ b/src/CharsetDetector.cs
@@ -383,12 +383,12 @@ namespace UtfUnknown
             if (buf0 == 0xFE && buf1 == 0xFF)
             {
                 // FE FF 00 00  UCS-4, unusual octet order BOM (3412)
-                return buf.Length > 2 && len > 2 && buf[2] == 0x00 && buf[3] == 0x00
+                return buf.Length > 3 && len > 3 && buf[2] == 0x00 && buf[3] == 0x00
                     ? CodepageName.X_ISO_10646_UCS_4_3412
                     : CodepageName.UTF16_BE;
             }
 
-            if (buf0 == 0x00 && buf1 == 0x00 && buf.Length > 2)
+            if (buf0 == 0x00 && buf1 == 0x00 && buf.Length > 3)
             {
                 if (buf[2] == 0xFE && buf[3] == 0xFF)
                     return CodepageName.UTF32_BE;
@@ -398,7 +398,7 @@ namespace UtfUnknown
             }
             else if (buf0 == 0xFF && buf1 == 0xFE)
             {
-                return buf.Length > 2 && len > 2 && buf[2] == 0x00 && buf[3] == 0x00
+                return buf.Length > 3 && len > 3 && buf[2] == 0x00 && buf[3] == 0x00
                     ? CodepageName.UTF32_LE
                     : CodepageName.UTF16_LE;
             }

--- a/src/CharsetDetector.cs
+++ b/src/CharsetDetector.cs
@@ -371,7 +371,7 @@ namespace UtfUnknown
 
         private static string FindCharSetByBom(byte[] buf, int len)
         {
-            if (len < 2 || buf.Length <= 2)
+            if (len < 2 || buf.Length < 2)
                 return null;
 
             var buf0 = buf[0];

--- a/src/CharsetDetector.cs
+++ b/src/CharsetDetector.cs
@@ -372,41 +372,41 @@ namespace UtfUnknown
         private static string FindCharSetByBom(byte[] buf, int len)
         {
             string bomSet = null;
-            if (len > 3)
+            if (len <= 3) return bomSet;
+            
+            //todo UTF bom of only 3 bytes isn't recognized
+            var b1 = buf[0];
+            var b2 = buf[1];
+            var b3 = buf[2];
+            var b4 = buf[3];
+            switch (b1)
             {
-                //todo UTF bom of only 3 bytes isn't recognized
-                var b1 = buf[0];
-                var b2 = buf[1];
-                var b3 = buf[2];
-                var b4 = buf[3];
-                switch (b1)
-                {
-                    case 0xEF:
-                        if (b2 == 0xBB && b3 == 0xBF)
-                            bomSet = CodepageName.UTF8;
-                        break;
-                    case 0xFE:
-                        if (b2 == 0xFF && b3 == 0x00 && b4 == 0x00)
-                            // FE FF 00 00  UCS-4, unusual octet order BOM (3412)
-                            bomSet = CodepageName.X_ISO_10646_UCS_4_3412;
-                        else if (0xFF == b2)
-                            bomSet = CodepageName.UTF16_BE;
-                        break;
-                    case 0x00:
-                        if (b2 == 0x00 && b3 == 0xFE && b4 == 0xFF)
-                            bomSet = CodepageName.UTF32_BE;
-                        else if (b2 == 0x00 && b3 == 0xFF && b4 == 0xFE)
-                            // 00 00 FF FE  UCS-4, unusual octet order BOM (2143)
-                            bomSet = CodepageName.X_ISO_10646_UCS_4_2143;
-                        break;
-                    case 0xFF:
-                        if (b2 == 0xFE && b3 == 0x00 && b4 == 0x00)
-                            bomSet = CodepageName.UTF32_LE;
-                        else if (b2 == 0xFE)
-                            bomSet = CodepageName.UTF16_LE;
-                        break;
-                } // switch
-            }
+                case 0xEF:
+                    if (b2 == 0xBB && b3 == 0xBF)
+                        bomSet = CodepageName.UTF8;
+                    break;
+                case 0xFE:
+                    if (b2 == 0xFF && b3 == 0x00 && b4 == 0x00)
+                        // FE FF 00 00  UCS-4, unusual octet order BOM (3412)
+                        bomSet = CodepageName.X_ISO_10646_UCS_4_3412;
+                    else if (0xFF == b2)
+                        bomSet = CodepageName.UTF16_BE;
+                    break;
+                case 0x00:
+                    if (b2 == 0x00 && b3 == 0xFE && b4 == 0xFF)
+                        bomSet = CodepageName.UTF32_BE;
+                    else if (b2 == 0x00 && b3 == 0xFF && b4 == 0xFE)
+                        // 00 00 FF FE  UCS-4, unusual octet order BOM (2143)
+                        bomSet = CodepageName.X_ISO_10646_UCS_4_2143;
+                    break;
+                case 0xFF:
+                    if (b2 == 0xFE && b3 == 0x00 && b4 == 0x00)
+                        bomSet = CodepageName.UTF32_LE;
+                    else if (b2 == 0xFE)
+                        bomSet = CodepageName.UTF16_LE;
+                    break;
+            } // switch
+            
             return bomSet;
         }
 

--- a/src/CharsetDetector.cs
+++ b/src/CharsetDetector.cs
@@ -382,27 +382,27 @@ namespace UtfUnknown
                 switch (b1)
                 {
                     case 0xEF:
-                        if (0xBB == b2 && 0xBF == b3)
+                        if (b2 == 0xBB && b3 == 0xBF)
                             bomSet = CodepageName.UTF8;
                         break;
                     case 0xFE:
-                        if (0xFF == b2 && 0x00 == b3 && 0x00 == b4)
+                        if (b2 == 0xFF && b3 == 0x00 && b4 == 0x00)
                             // FE FF 00 00  UCS-4, unusual octet order BOM (3412)
                             bomSet = CodepageName.X_ISO_10646_UCS_4_3412;
                         else if (0xFF == b2)
                             bomSet = CodepageName.UTF16_BE;
                         break;
                     case 0x00:
-                        if (0x00 == b2 && 0xFE == b3 && 0xFF == b4)
+                        if (b2 == 0x00 && b3 == 0xFE && b4 == 0xFF)
                             bomSet = CodepageName.UTF32_BE;
-                        else if (0x00 == b2 && 0xFF == b3 && 0xFE == b4)
+                        else if (b2 == 0x00 && b3 == 0xFF && b4 == 0xFE)
                             // 00 00 FF FE  UCS-4, unusual octet order BOM (2143)
                             bomSet = CodepageName.X_ISO_10646_UCS_4_2143;
                         break;
                     case 0xFF:
-                        if (0xFE == b2 && 0x00 == b3 && 0x00 == b4)
+                        if (b2 == 0xFE && b3 == 0x00 && b4 == 0x00)
                             bomSet = CodepageName.UTF32_LE;
-                        else if (0xFE == b2)
+                        else if (b2 == 0xFE)
                             bomSet = CodepageName.UTF16_LE;
                         break;
                 } // switch

--- a/src/CharsetDetector.cs
+++ b/src/CharsetDetector.cs
@@ -377,30 +377,38 @@ namespace UtfUnknown
             var buf0 = buf[0];
             var buf1 = buf[1];
             
-            if (buf0 == 0xEF && buf1 == 0xBB && buf.Length > 2 && len > 2 && buf[2] == 0xBF)
-                return CodepageName.UTF8;
+            if (buf0 == 0xEF && buf1 == 0xBB
+                && buf.Length > 2 && len > 2
+                    && buf[2] == 0xBF)
+                        return CodepageName.UTF8;
 
             if (buf0 == 0xFE && buf1 == 0xFF)
             {
                 // FE FF 00 00  UCS-4, unusual octet order BOM (3412)
-                return buf.Length > 3 && len > 3 && buf[2] == 0x00 && buf[3] == 0x00
-                    ? CodepageName.X_ISO_10646_UCS_4_3412
-                    : CodepageName.UTF16_BE;
+                return buf.Length > 3 && len > 3
+                    && buf[2] == 0x00 && buf[3] == 0x00
+                        ? CodepageName.X_ISO_10646_UCS_4_3412
+                        : CodepageName.UTF16_BE;
             }
 
-            if (buf0 == 0x00 && buf1 == 0x00 && buf.Length > 3)
+            if (buf0 == 0x00 && buf1 == 0x00)
             {
+                if (buf.Length <= 3)
+                    return null;
+                
                 if (buf[2] == 0xFE && buf[3] == 0xFF)
                     return CodepageName.UTF32_BE;
+
                 // 00 00 FF FE  UCS-4, unusual octet order BOM (2143)
                 if (buf[2] == 0xFF && buf[3] == 0xFE)
                     return CodepageName.X_ISO_10646_UCS_4_2143;
             }
             else if (buf0 == 0xFF && buf1 == 0xFE)
             {
-                return buf.Length > 3 && len > 3 && buf[2] == 0x00 && buf[3] == 0x00
-                    ? CodepageName.UTF32_LE
-                    : CodepageName.UTF16_LE;
+                return buf.Length > 3 && len > 3
+                    && buf[2] == 0x00 && buf[3] == 0x00
+                        ? CodepageName.UTF32_LE
+                        : CodepageName.UTF16_LE;
             }
 
             return null;

--- a/src/CharsetDetector.cs
+++ b/src/CharsetDetector.cs
@@ -371,40 +371,39 @@ namespace UtfUnknown
 
         private static string FindCharSetByBom(byte[] buf, int len)
         {
-            string bomSet = null;
-            if (buf.Length <= 2) return bomSet;
+            if (len < 2 || buf.Length <= 2)
+                return null;
 
             var buf0 = buf[0];
             var buf1 = buf[1];
-            switch (buf0)
-            {
-                case 0xEF:
-                    if (buf.Length > 2 && buf1 == 0xBB && buf[2] == 0xBF)
-                        bomSet = CodepageName.UTF8;
-                    break;
-                case 0xFE:
-                    if (buf.Length > 2 && buf1 == 0xFF && buf[2] == 0x00 && buf[3] == 0x00)
-                        // FE FF 00 00  UCS-4, unusual octet order BOM (3412)
-                        bomSet = CodepageName.X_ISO_10646_UCS_4_3412;
-                    else if (buf1 == 0xFF)
-                        bomSet = CodepageName.UTF16_BE;
-                    break;
-                case 0x00:
-                    if (buf.Length > 2 && buf1 == 0x00 && buf[2] == 0xFE && buf[3] == 0xFF)
-                        bomSet = CodepageName.UTF32_BE;
-                    else if (buf.Length > 2 && buf1 == 0x00 && buf[2] == 0xFF && buf[3] == 0xFE)
-                        // 00 00 FF FE  UCS-4, unusual octet order BOM (2143)
-                        bomSet = CodepageName.X_ISO_10646_UCS_4_2143;
-                    break;
-                case 0xFF:
-                    if (buf.Length > 2 && buf1 == 0xFE && buf[2] == 0x00 && buf[3] == 0x00)
-                        bomSet = CodepageName.UTF32_LE;
-                    else if (buf1 == 0xFE)
-                        bomSet = CodepageName.UTF16_LE;
-                    break;
-            } // switch
             
-            return bomSet;
+            if (buf0 == 0xEF && buf1 == 0xBB && buf.Length > 2 && len > 2 && buf[2] == 0xBF)
+                return CodepageName.UTF8;
+
+            if (buf0 == 0xFE && buf1 == 0xFF)
+            {
+                // FE FF 00 00  UCS-4, unusual octet order BOM (3412)
+                return buf.Length > 2 && len > 2 && buf[2] == 0x00 && buf[3] == 0x00
+                    ? CodepageName.X_ISO_10646_UCS_4_3412
+                    : CodepageName.UTF16_BE;
+            }
+
+            if (buf0 == 0x00 && buf1 == 0x00 && buf.Length > 2)
+            {
+                if (buf[2] == 0xFE && buf[3] == 0xFF)
+                    return CodepageName.UTF32_BE;
+                // 00 00 FF FE  UCS-4, unusual octet order BOM (2143)
+                if (buf[2] == 0xFF && buf[3] == 0xFE)
+                    return CodepageName.X_ISO_10646_UCS_4_2143;
+            }
+            else if (buf0 == 0xFF && buf1 == 0xFE)
+            {
+                return buf.Length > 2 && len > 2 && buf[2] == 0x00 && buf[3] == 0x00
+                    ? CodepageName.UTF32_LE
+                    : CodepageName.UTF16_LE;
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/src/CharsetDetector.cs
+++ b/src/CharsetDetector.cs
@@ -372,37 +372,34 @@ namespace UtfUnknown
         private static string FindCharSetByBom(byte[] buf, int len)
         {
             string bomSet = null;
-            if (len <= 3) return bomSet;
-            
-            //todo UTF bom of only 3 bytes isn't recognized
-            var b1 = buf[0];
-            var b2 = buf[1];
-            var b3 = buf[2];
-            var b4 = buf[3];
-            switch (b1)
+            if (buf.Length <= 2) return bomSet;
+
+            var buf0 = buf[0];
+            var buf1 = buf[1];
+            switch (buf0)
             {
                 case 0xEF:
-                    if (b2 == 0xBB && b3 == 0xBF)
+                    if (buf.Length > 2 && buf1 == 0xBB && buf[2] == 0xBF)
                         bomSet = CodepageName.UTF8;
                     break;
                 case 0xFE:
-                    if (b2 == 0xFF && b3 == 0x00 && b4 == 0x00)
+                    if (buf.Length > 2 && buf1 == 0xFF && buf[2] == 0x00 && buf[3] == 0x00)
                         // FE FF 00 00  UCS-4, unusual octet order BOM (3412)
                         bomSet = CodepageName.X_ISO_10646_UCS_4_3412;
-                    else if (0xFF == b2)
+                    else if (buf1 == 0xFF)
                         bomSet = CodepageName.UTF16_BE;
                     break;
                 case 0x00:
-                    if (b2 == 0x00 && b3 == 0xFE && b4 == 0xFF)
+                    if (buf.Length > 2 && buf1 == 0x00 && buf[2] == 0xFE && buf[3] == 0xFF)
                         bomSet = CodepageName.UTF32_BE;
-                    else if (b2 == 0x00 && b3 == 0xFF && b4 == 0xFE)
+                    else if (buf.Length > 2 && buf1 == 0x00 && buf[2] == 0xFF && buf[3] == 0xFE)
                         // 00 00 FF FE  UCS-4, unusual octet order BOM (2143)
                         bomSet = CodepageName.X_ISO_10646_UCS_4_2143;
                     break;
                 case 0xFF:
-                    if (b2 == 0xFE && b3 == 0x00 && b4 == 0x00)
+                    if (buf.Length > 2 && buf1 == 0xFE && buf[2] == 0x00 && buf[3] == 0x00)
                         bomSet = CodepageName.UTF32_LE;
-                    else if (b2 == 0xFE)
+                    else if (buf1 == 0xFE)
                         bomSet = CodepageName.UTF16_LE;
                     break;
             } // switch

--- a/tests/CharsetDetectorTest.cs
+++ b/tests/CharsetDetectorTest.cs
@@ -82,6 +82,16 @@ namespace UtfUnknown.Tests
             Assert.AreEqual(Charsets.UTF8, result.Detected.EncodingName);
             Assert.AreEqual(1.0f, result.Detected.Confidence);
         }
+        
+        [Test]
+        public void Test2byteArrayBomUTF16_BE()
+        {
+            byte[] buf = { 0xFE, 0xFF, };
+
+            var result = CharsetDetector.DetectFromBytes(buf);
+            Assert.AreEqual(Charsets.UTF16_BE, result.Detected.EncodingName);
+            Assert.AreEqual(1.0f, result.Detected.Confidence);
+        }
 
         [Test]
         public void TestBomUTF16_BE()
@@ -115,6 +125,15 @@ namespace UtfUnknown.Tests
             Assert.AreEqual(1.0f, result.Detected.Confidence);
         }
 
+        [Test]
+        public void Test2byteArrayBomUTF16_LE()
+        {
+            byte[] buf = { 0xFF, 0xFE, };
+            var result = CharsetDetector.DetectFromBytes(buf);
+            Assert.AreEqual(Charsets.UTF16_LE, result.Detected.EncodingName);
+            Assert.AreEqual(1.0f, result.Detected.Confidence);
+        }
+        
         [Test]
         public void TestBomUTF16_LE()
         {


### PR DESCRIPTION
Hello!

This pr support 2-byte arrays for utf with BOM.

https://github.com/CharsetDetector/UTF-unknown/blob/cc2b081a621001aedfac20229bd555585d366e9f/src/CharsetDetector.cs#L377