### PR TITLE
Fix todo: ISO-2022-CN is x-cp50227 in .NET

### DIFF
--- a/src/Core/CodepageName.cs
+++ b/src/Core/CodepageName.cs
@@ -91,7 +91,7 @@ namespace UtfUnknown.Core
         internal const string EUC_TW = "euc-tw";
         
         /// <summary>
-        /// ISO 2022 Chinese codepage name.
+        /// ISO 2022 Chinese codepage name (Codepage 50227).
         /// </summary>
         /// <remarks>
         /// Supported by alias is x-cp50227 in. NET. Codepage identifier 50229 is currently unsupported (see for example https://github.com/microsoft/referencesource/blob/17b97365645da62cf8a49444d979f94a59bbb155/mscorlib/system/text/iso2022encoding.cs#L92).

--- a/src/Core/CodepageName.cs
+++ b/src/Core/CodepageName.cs
@@ -91,7 +91,7 @@ namespace UtfUnknown.Core
         internal const string EUC_TW = "euc-tw";
         
         /// <summary>
-        /// ISO 2022 Chinese codepage name (Codepage 50227).
+        /// ISO 2022 Chinese codepage name.
         /// </summary>
         /// <remarks>
         /// Supported by alias is x-cp50227 in. NET. Codepage identifier 50229 is currently unsupported (see for example https://github.com/microsoft/referencesource/blob/17b97365645da62cf8a49444d979f94a59bbb155/mscorlib/system/text/iso2022encoding.cs#L92).
@@ -112,7 +112,7 @@ namespace UtfUnknown.Core
         internal const string ISO_2022_JP = "iso-2022-jp";
 
         /// <summary>
-        /// ISO 2022 Simplified Chinese codepage name.
+        /// ISO 2022 Simplified Chinese codepage name (Codepage 50227).
         /// </summary>
         /// <remarks>
         /// Other alias is cp50227.

--- a/src/Core/CodepageName.cs
+++ b/src/Core/CodepageName.cs
@@ -94,9 +94,9 @@ namespace UtfUnknown.Core
         /// ISO 2022 Chinese codepage name.
         /// </summary>
         /// <remarks>
-        /// Other alias is cp50227. Codepage identifier 50229 is currently unsupported (see for example https://github.com/microsoft/referencesource/blob/17b97365645da62cf8a49444d979f94a59bbb155/mscorlib/system/text/iso2022encoding.cs#L92).
+        /// Supported by alias is x-cp50227 in. NET. Codepage identifier 50229 is currently unsupported (see for example https://github.com/microsoft/referencesource/blob/17b97365645da62cf8a49444d979f94a59bbb155/mscorlib/system/text/iso2022encoding.cs#L92).
         /// </remarks>
-        internal const string ISO_2022_CN = "x-cp50227";
+        internal const string ISO_2022_CN = "iso-2022-ch";
         
         /// <summary>
         /// ISO 2022 Korean codepage name.
@@ -110,6 +110,14 @@ namespace UtfUnknown.Core
         /// ISO 2022 Japanese codepage name.
         /// </summary>
         internal const string ISO_2022_JP = "iso-2022-jp";
+
+        /// <summary>
+        /// ISO 2022 Simplified Chinese codepage name.
+        /// </summary>
+        /// <remarks>
+        /// Other alias is cp50227.
+        /// </remarks>
+        internal const string X_CP50227 = "x-cp50227";
         
         /// <summary>
         /// Big5 codepage name.

--- a/src/Core/CodepageName.cs
+++ b/src/Core/CodepageName.cs
@@ -94,9 +94,9 @@ namespace UtfUnknown.Core
         /// ISO 2022 Chinese codepage name.
         /// </summary>
         /// <remarks>
-        /// TODO: Not supported? Maybe fix to x-cp50227?
+        /// Other alias is cp50227. Codepage identifier 50229 is currently unsupported (see for example https://github.com/microsoft/referencesource/blob/17b97365645da62cf8a49444d979f94a59bbb155/mscorlib/system/text/iso2022encoding.cs#L92).
         /// </remarks>
-        internal const string ISO_2022_CN = "iso-2022-ch";
+        internal const string ISO_2022_CN = "x-cp50227";
         
         /// <summary>
         /// ISO 2022 Korean codepage name.

--- a/src/Core/CodepageName.cs
+++ b/src/Core/CodepageName.cs
@@ -96,7 +96,7 @@ namespace UtfUnknown.Core
         /// <remarks>
         /// Supported by alias is x-cp50227 in. NET. Codepage identifier 50229 is currently unsupported (see for example https://github.com/microsoft/referencesource/blob/17b97365645da62cf8a49444d979f94a59bbb155/mscorlib/system/text/iso2022encoding.cs#L92).
         /// </remarks>
-        internal const string ISO_2022_CN = "iso-2022-ch";
+        internal const string ISO_2022_CN = "iso-2022-cn";
         
         /// <summary>
         /// ISO 2022 Korean codepage name.

--- a/src/Core/CodepageName.cs
+++ b/src/Core/CodepageName.cs
@@ -94,7 +94,7 @@ namespace UtfUnknown.Core
         /// ISO 2022 Chinese codepage name.
         /// </summary>
         /// <remarks>
-        /// Supported by alias is x-cp50227 in. NET. Codepage identifier 50229 is currently unsupported (see for example https://github.com/microsoft/referencesource/blob/17b97365645da62cf8a49444d979f94a59bbb155/mscorlib/system/text/iso2022encoding.cs#L92).
+        /// Supported by alias is x-cp50227 (Codepage 50227) in. NET. Codepage identifier 50229 is currently unsupported (see for example https://github.com/microsoft/referencesource/blob/17b97365645da62cf8a49444d979f94a59bbb155/mscorlib/system/text/iso2022encoding.cs#L92).
         /// </remarks>
         internal const string ISO_2022_CN = "iso-2022-cn";
         
@@ -112,7 +112,7 @@ namespace UtfUnknown.Core
         internal const string ISO_2022_JP = "iso-2022-jp";
 
         /// <summary>
-        /// ISO 2022 Simplified Chinese codepage name (Codepage 50227).
+        /// ISO 2022 Simplified Chinese codepage name.
         /// </summary>
         /// <remarks>
         /// Other alias is cp50227.

--- a/src/DetectionDetail.cs
+++ b/src/DetectionDetail.cs
@@ -19,7 +19,8 @@ namespace UtfUnknown
             new Dictionary<string, string>
             {
                 // CP949 is superset of ks_c_5601-1987 (see https://github.com/CharsetDetector/UTF-unknown/pull/74#issuecomment-550362133)
-                {CodepageName.CP949, CodepageName.KS_C_5601_1987}
+                {CodepageName.CP949, CodepageName.KS_C_5601_1987},
+                {CodepageName.ISO_2022_CN, CodepageName.X_CP50227},
             };
 
         /// <summary>


### PR DESCRIPTION
Resolve task  #78
> Not supported iso-2022-ch? Maybe fix to x-cp50227?

Sorry, but I could not find an example.