### PR TITLE
Overload of DetectFromBytes(byte[] bytes, int offset, int len)

### DIFF
--- a/src/CharsetDetector.cs
+++ b/src/CharsetDetector.cs
@@ -306,7 +306,7 @@ namespace UtfUnknown
                     return;
             }
 
-            FindInputState(buf, len);
+            FindInputState(buf, offset, len);
             foreach (var prober in CharsetProbers)
             {
                 _done = RunProber(buf, offset, len, prober);
@@ -337,12 +337,12 @@ namespace UtfUnknown
             return false;
         }
 
-        private void FindInputState(byte[] buf, int len)
+        private void FindInputState(byte[] buf, int offset, int len)
         {
             for (int i = 0; i < len; i++)
             {
                 // other than 0xa0, if every other character is ascii, the page is ascii
-                if ((buf[i] & 0x80) != 0 && buf[i] != 0xA0)
+                if ((buf[offset + i] & 0x80) != 0 && buf[offset + i] != 0xA0)
                 {
                     // we got a non-ascii byte (high-byte)
                     if (InputState != InputState.Highbyte)
@@ -357,13 +357,13 @@ namespace UtfUnknown
                 else
                 {
                     if (InputState == InputState.PureASCII &&
-                        (buf[i] == 0x1B || (buf[i] == 0x7B && _lastChar == 0x7E)))
+                        (buf[offset + i] == 0x1B || (buf[offset + i] == 0x7B && _lastChar == 0x7E)))
                     {
                         // found escape character or HZ "~{"
                         InputState = InputState.EscASCII;
                         _escCharsetProber = _escCharsetProber ?? GetNewProbers();
                     }
-                    _lastChar = buf[i];
+                    _lastChar = buf[offset + i];
                 }
             }
         }

--- a/src/CharsetDetector.cs
+++ b/src/CharsetDetector.cs
@@ -118,8 +118,9 @@ namespace UtfUnknown
 
         /// <summary>
         /// Detect the character encoding form this byte array.
+        /// It searchs for BOM from bytes[0].
         /// </summary>
-        /// <param name="bytes"></param>
+        /// <param name="bytes">The byte array containing the text</param>
         /// <returns></returns>
         public static DetectionResult DetectFromBytes(byte[] bytes)
         {
@@ -134,11 +135,12 @@ namespace UtfUnknown
         }
 
         /// <summary>
-        /// Detect the character encoding form this byte array.
+        /// Detect the character encoding form this byte array. 
+        /// It searchs for BOM from bytes[offset].
         /// </summary>
-        /// <param name="bytes"></param>
-        /// <param name="offset"></param>
-        /// <param name="len"></param>
+        /// <param name="bytes">The byte array containing the text</param>
+        /// <param name="offset">The zero-based byte offset in buffer at which to begin reading the data from</param>
+        /// <param name="len">The maximum number of bytes to be read</param>
         /// <returns></returns>
         public static DetectionResult DetectFromBytes(byte[] bytes, int offset, int len)
         {
@@ -154,9 +156,9 @@ namespace UtfUnknown
             {
                 throw new ArgumentOutOfRangeException(nameof(len));
             }
-            if (bytes.Length - offset < len)
+            if (bytes.Length < offset + len)
             {
-                throw new ArgumentOutOfRangeException(nameof(len));
+                throw new ArgumentException($"{nameof(len)} is greater than the number of bytes from {nameof(offset)} to the end of the array.");
             }
 
             var detector = new CharsetDetector();

--- a/src/CharsetDetector.cs
+++ b/src/CharsetDetector.cs
@@ -339,7 +339,7 @@ namespace UtfUnknown
 
         private void FindInputState(byte[] buf, int offset, int len)
         {
-            for (int i = 0; i < len; i++)
+            for (int i = offset; i < len; i++)
             {
                 // other than 0xa0, if every other character is ascii, the page is ascii
                 if ((buf[offset + i] & 0x80) != 0 && buf[offset + i] != 0xA0)

--- a/src/CharsetDetector.cs
+++ b/src/CharsetDetector.cs
@@ -133,6 +133,37 @@ namespace UtfUnknown
             return detector.DataEnd();
         }
 
+        /// <summary>
+        /// Detect the character encoding form this byte array.
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <param name="offset"></param>
+        /// <param name="len"></param>
+        /// <returns></returns>
+        public static DetectionResult DetectFromBytes(byte[] bytes, int offset, int len)
+        {
+            if (bytes == null)
+            {
+                throw new ArgumentNullException(nameof(bytes));
+            }
+            if (offset < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
+            if (len < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(len));
+            }
+            if (bytes.Length - offset < len)
+            {
+                throw new ArgumentOutOfRangeException(nameof(len));
+            }
+
+            var detector = new CharsetDetector();
+            detector.Feed(bytes, offset, len);
+            return detector.DataEnd();
+        }
+
 #if !NETSTANDARD1_0
 
         /// <summary>

--- a/src/CharsetDetector.cs
+++ b/src/CharsetDetector.cs
@@ -342,7 +342,7 @@ namespace UtfUnknown
             for (int i = offset; i < len; i++)
             {
                 // other than 0xa0, if every other character is ascii, the page is ascii
-                if ((buf[offset + i] & 0x80) != 0 && buf[offset + i] != 0xA0)
+                if ((buf[i] & 0x80) != 0 && buf[i] != 0xA0)
                 {
                     // we got a non-ascii byte (high-byte)
                     if (InputState != InputState.Highbyte)
@@ -357,13 +357,13 @@ namespace UtfUnknown
                 else
                 {
                     if (InputState == InputState.PureASCII &&
-                        (buf[offset + i] == 0x1B || (buf[offset + i] == 0x7B && _lastChar == 0x7E)))
+                        (buf[i] == 0x1B || (buf[i] == 0x7B && _lastChar == 0x7E)))
                     {
                         // found escape character or HZ "~{"
                         InputState = InputState.EscASCII;
                         _escCharsetProber = _escCharsetProber ?? GetNewProbers();
                     }
-                    _lastChar = buf[offset + i];
+                    _lastChar = buf[i];
                 }
             }
         }

--- a/src/UTF-unknown.csproj
+++ b/src/UTF-unknown.csproj
@@ -20,24 +20,6 @@
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.Memory">
-      <Version>4.5.3</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Memory">
-      <Version>4.5.3</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
-    <PackageReference Include="System.Memory">
-      <Version>4.5.3</Version>
-    </PackageReference>
-  </ItemGroup>
-
   <PropertyGroup>
     <Authors>Julian Verdurmen, Rustam Sayfutdinov, Rudi Pettazzi, Shy Shalom</Authors>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/src/UTF-unknown.csproj
+++ b/src/UTF-unknown.csproj
@@ -20,6 +20,24 @@
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.Memory">
+      <Version>4.5.3</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory">
+      <Version>4.5.3</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="System.Memory">
+      <Version>4.5.3</Version>
+    </PackageReference>
+  </ItemGroup>
+
   <PropertyGroup>
     <Authors>Julian Verdurmen, Rustam Sayfutdinov, Rudi Pettazzi, Shy Shalom</Authors>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/tests/CharsetDetectorTest.cs
+++ b/tests/CharsetDetectorTest.cs
@@ -59,7 +59,26 @@ namespace UtfUnknown.Tests
             // Assert
             Assert.AreEqual(expectedPosition, stream.Position);
         }
-        
+
+        [Test]
+        [TestCase(0, 10, CodepageName.ASCII)]
+        [TestCase(0, 100, CodepageName.UTF8)]
+        [TestCase(10, 100, CodepageName.UTF8)]
+        public void DetectFromByteArray(int offset, int len, string detectedCodepage)
+        {
+            // Arrange
+            string s = "UTF-Unknown은 파일, 스트림, 그 외 바이트 배열의 캐릭터 셋을 탐지하는 라이브러리입니다." + 
+                "대한민국 (大韓民國, Republic of Korea)";
+            byte[] bytes = Encoding.UTF8.GetBytes(s);
+
+            // Act
+            var result = CharsetDetector.DetectFromBytes(bytes, offset, len);
+
+            // Assert
+            Assert.AreEqual(detectedCodepage, result.Detected.EncodingName);
+            Assert.AreEqual(1.0f, result.Detected.Confidence);
+        }
+
         [Test]
         [TestCase(new byte[] { 0x2B, 0x2F, 0x76, 0x38 })]
         [TestCase(new byte[] { 0x2B, 0x2F, 0x76, 0x39 })]


### PR DESCRIPTION
I added an overload of `CharsetDetector.DetectFromBytes()`, by providing the offset and length parameters.

`CharsetDetector.DetectFromBytes(byte[] bytes)` does not support checking a subset of the byte array, like how `Stream` does in `Read()` and `Write()`. The new overload enables such operation.