### PR TITLE
Add .NET Framework Targeting Pack Nuget Packages

### DIFF
--- a/src/UTF-unknown.csproj
+++ b/src/UTF-unknown.csproj
@@ -20,6 +20,13 @@
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
   <PropertyGroup>
     <Authors>Julian Verdurmen, Rustam Sayfutdinov, Rudi Pettazzi, Shy Shalom</Authors>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/tests/UTF-unknown.Tests.csproj
+++ b/tests/UTF-unknown.Tests.csproj
@@ -15,6 +15,13 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\src\UTF-unknown.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Hello!

Add .NET Framework Targeting Pack Nuget Packages

> These packages enable building .NET Framework projects on any machine with at least MSBuild or the .NET Core SDK installed. 
>
> The following scenarios and benefits are enabled for .NET Framework projects:
>
>- Build without requiring admin operations to install pre-requisites such as [Visual Studio](https://visualstudio.microsoft.com/vs/) or [.NET Framework targeting packs](https://dotnet.microsoft.com/download/visual-studio-sdks).
>- Build libraries on any operating system supported by the .NET Core SDK.
>- Build Mono-based projects.
>
> https://github.com/microsoft/dotnet/blob/master/releases/reference-assemblies/README.md#net-framework-targeting-pack-nuget-packages