### PR TITLE
Enable nullable reference types for main source code

### DIFF
--- a/example/ConsoleExample.csproj
+++ b/example/ConsoleExample.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/example/DetectFile.cs
+++ b/example/DetectFile.cs
@@ -27,7 +27,7 @@ namespace ConsoleExample
 
             var result = CharsetDetector.DetectFromFile(filename);
             var message = result.Detected != null
-                ? $"Detected encoding {result.Detected.Encoding.WebName} with confidence {result.Detected.Confidence}."
+                ? $"Detected encoding {result.Detected.Encoding?.WebName} with confidence {result.Detected.Confidence}."
                 : $"Detection failed: {filename}";
             Console.WriteLine(message);
         }

--- a/example/app.config
+++ b/example/app.config
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>

--- a/src/CharsetDetector.cs
+++ b/src/CharsetDetector.cs
@@ -45,6 +45,8 @@ using System.Linq;
 using UtfUnknown.Core;
 using UtfUnknown.Core.Probers;
 
+#nullable enable
+
 namespace UtfUnknown
 {
     /// <summary>
@@ -78,14 +80,14 @@ namespace UtfUnknown
         /// <summary>
         /// "list" of probers
         /// </summary>
-        private IList<CharsetProber> _charsetProbers;
+        private IList<CharsetProber>? _charsetProbers;
 
         /// <summary>
         /// TODO unknown
         /// </summary>
-        private IList<CharsetProber> _escCharsetProber;
+        private IList<CharsetProber>? _escCharsetProber;
 
-        private IList<CharsetProber> CharsetProbers
+        private IList<CharsetProber>? CharsetProbers
         {
             get
             {
@@ -105,7 +107,7 @@ namespace UtfUnknown
         /// <summary>
         /// Detected charset. Most of the time <see cref="_done"/> is true
         /// </summary>
-        private DetectionDetail _detectionDetail;
+        private DetectionDetail? _detectionDetail;
 
         private const float MinimumThreshold = 0.20f;
 
@@ -309,6 +311,9 @@ namespace UtfUnknown
             }
 
             FindInputState(buf, offset, len);
+
+            if (CharsetProbers == null)
+                return;
             foreach (var prober in CharsetProbers)
             {
                 _done = RunProber(buf, offset, len, prober);
@@ -370,7 +375,7 @@ namespace UtfUnknown
             }
         }
 
-        private static string FindCharSetByBom(byte[] buf, int offset, int len)
+        private static string? FindCharSetByBom(byte[] buf, int offset, int len)
         {
             if (len < 2)
                 return null;
@@ -452,7 +457,7 @@ namespace UtfUnknown
 
             if (InputState == InputState.Highbyte)
             {
-                var detectionResults = _charsetProbers
+                var detectionResults = _charsetProbers?
                     .Select(prober => new DetectionDetail(prober))
                     .Where(result => result.Confidence > MinimumThreshold)
                     .OrderByDescending(result => result.Confidence)

--- a/src/DetectionDetail.cs
+++ b/src/DetectionDetail.cs
@@ -5,6 +5,8 @@ using System.Text;
 using UtfUnknown.Core;
 using UtfUnknown.Core.Probers;
 
+#nullable enable
+
 [assembly: InternalsVisibleTo("UtfUnknown.Tests, PublicKey=" +
 "002400000480000094000000060200000024000052534131000400000100010029f6b4defac763" +
 "66721687460b44b7619e8e19a411f785279316fdae2f6965edfa4a460304fe8b4ed796d5356a1c" +
@@ -32,8 +34,8 @@ namespace UtfUnknown
         /// <summary>
         /// New result
         /// </summary>
-        public DetectionDetail(string encodingShortName, float confidence, CharsetProber prober = null,
-            TimeSpan? time = null, string statusLog = null)
+        public DetectionDetail(string encodingShortName, float confidence, CharsetProber? prober = null,
+            TimeSpan? time = null, string? statusLog = null)
         {
             EncodingName = encodingShortName;
             Confidence = confidence;
@@ -59,7 +61,7 @@ namespace UtfUnknown
         /// <summary>
         /// The detected encoding. 
         /// </summary>
-        public Encoding Encoding { get; set; }
+        public Encoding? Encoding { get; set; }
 
         /// <summary>
         /// The confidence of the found encoding. Between 0 and 1.
@@ -69,21 +71,21 @@ namespace UtfUnknown
         /// <summary>
         /// The used prober for detection
         /// </summary>
-        public CharsetProber Prober { get; set; }
+        public CharsetProber? Prober { get; set; }
 
         /// <summary>
         /// The time spend
         /// </summary>
         public TimeSpan? Time { get; set; }
 
-        public string StatusLog { get; set; }
+        public string? StatusLog { get; set; }
 
         public override string ToString()
         {
             return $"Detected {EncodingName} with confidence of {Confidence}";
         }
 
-        internal static Encoding GetEncoding(string encodingShortName)
+        internal static Encoding? GetEncoding(string encodingShortName)
         {
             var encodingName = FixedToSupportCodepageName.TryGetValue(encodingShortName, out var supportCodepageName)
                 ? supportCodepageName

--- a/src/DetectionResult.cs
+++ b/src/DetectionResult.cs
@@ -1,6 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace UtfUnknown
 {
@@ -19,7 +20,7 @@ namespace UtfUnknown
         /// <summary>
         /// Multiple results
         /// </summary>
-        public DetectionResult(IList<DetectionDetail> details)
+        public DetectionResult(IList<DetectionDetail>? details)
         {
             Details = details;
         }
@@ -36,16 +37,16 @@ namespace UtfUnknown
         /// <summary>
         /// Get the best Detection
         /// </summary>
-        public DetectionDetail Detected => Details?.FirstOrDefault();
+        public DetectionDetail? Detected => Details?.FirstOrDefault();
 
         /// <summary>
         /// All results
         /// </summary>
-        public IList<DetectionDetail> Details { get; set; }
+        public IList<DetectionDetail>? Details { get; set; }
 
         public override string ToString()
         {
-            return $"{nameof(Detected)}: {Detected}, \n{nameof(Details)}:\n - {string.Join("\n- ", Details?.Select(d => d.ToString()))}";
+            return $"{nameof(Detected)}: {Detected}, \n{nameof(Details)}:\n - {string.Join("\n- ", Details?.Select(d => d.ToString()) ?? new[] { string.Empty })}";
         }
     }
 }

--- a/src/UTF-unknown.csproj
+++ b/src/UTF-unknown.csproj
@@ -14,6 +14,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard2.0' ">

--- a/tests/CharsetDetectorTest.cs
+++ b/tests/CharsetDetectorTest.cs
@@ -28,7 +28,7 @@ namespace UtfUnknown.Tests
             using (stream)
             {
                 var result = CharsetDetector.DetectFromStream(stream);
-                Assert.AreEqual(CodepageName.ASCII, result.Detected.EncodingName);
+                Assert.AreEqual(CodepageName.ASCII, result.Detected!.EncodingName);
                 Assert.AreEqual(1.0f, result.Detected.Confidence);
             }
         }
@@ -75,7 +75,7 @@ namespace UtfUnknown.Tests
             var result = CharsetDetector.DetectFromBytes(bytes, offset, len);
 
             // Assert
-            Assert.AreEqual(detectedCodepage, result.Detected.EncodingName);
+            Assert.AreEqual(detectedCodepage, result.Detected!.EncodingName);
             Assert.AreEqual(1.0f, result.Detected.Confidence);
         }
 
@@ -89,7 +89,7 @@ namespace UtfUnknown.Tests
         {
             var result = CharsetDetector.DetectFromBytes(bufferBytes)
                 .Detected;
-            Assert.AreEqual(CodepageName.UTF7, result.EncodingName);
+            Assert.AreEqual(CodepageName.UTF7, result!.EncodingName);
             Assert.AreEqual(1.0f, result.Confidence);
         }
         
@@ -99,7 +99,7 @@ namespace UtfUnknown.Tests
             var bufferBytes = new byte[] { 0x84, 0x31, 0x95, 0x33 };
             var result = CharsetDetector.DetectFromBytes(bufferBytes)
                 .Detected;
-            Assert.AreEqual(CodepageName.GB18030, result.EncodingName);
+            Assert.AreEqual(CodepageName.GB18030, result!.EncodingName);
             Assert.AreEqual(1.0f, result.Confidence);
         }
 
@@ -112,7 +112,7 @@ namespace UtfUnknown.Tests
                        "利用案内でどうぞ。";
             byte[] buf = Encoding.UTF8.GetBytes(s);
             var result = CharsetDetector.DetectFromBytes(buf);
-            Assert.AreEqual(CodepageName.UTF8, result.Detected.EncodingName);
+            Assert.AreEqual(CodepageName.UTF8, result.Detected!.EncodingName);
             Assert.AreEqual(1.0f, result.Detected.Confidence);
         }
 
@@ -121,7 +121,7 @@ namespace UtfUnknown.Tests
         {
             byte[] buf = { 0xEF, 0xBB, 0xBF, 0x68, 0x65, 0x6C, 0x6C, 0x6F, 0x21 };
             var result = CharsetDetector.DetectFromBytes(buf);
-            Assert.AreEqual(CodepageName.UTF8, result.Detected.EncodingName);
+            Assert.AreEqual(CodepageName.UTF8, result.Detected!.EncodingName);
             Assert.AreEqual(1.0f, result.Detected.Confidence);
         }
         
@@ -131,7 +131,7 @@ namespace UtfUnknown.Tests
             byte[] buf = { 0xFE, 0xFF, };
 
             var result = CharsetDetector.DetectFromBytes(buf);
-            Assert.AreEqual(CodepageName.UTF16_BE, result.Detected.EncodingName);
+            Assert.AreEqual(CodepageName.UTF16_BE, result.Detected!.EncodingName);
             Assert.AreEqual(1.0f, result.Detected.Confidence);
         }
 
@@ -141,7 +141,7 @@ namespace UtfUnknown.Tests
             byte[] buf = { 0xFE, 0xFF, 0x00, 0x68, 0x00, 0x65 };
 
             var result = CharsetDetector.DetectFromBytes(buf);
-            Assert.AreEqual(CodepageName.UTF16_BE, result.Detected.EncodingName);
+            Assert.AreEqual(CodepageName.UTF16_BE, result.Detected!.EncodingName);
             Assert.AreEqual(1.0f, result.Detected.Confidence);
         }
 
@@ -152,7 +152,7 @@ namespace UtfUnknown.Tests
             byte[] buf = { 0xFE, 0xFF, 0x00, 0x00, 0x65 };
 
             var result = CharsetDetector.DetectFromBytes(buf);
-            Assert.AreEqual(CodepageName.X_ISO_10646_UCS_4_3412, result.Detected.EncodingName);
+            Assert.AreEqual(CodepageName.X_ISO_10646_UCS_4_3412, result.Detected!.EncodingName);
             Assert.AreEqual(1.0f, result.Detected.Confidence);
         }
 
@@ -163,7 +163,7 @@ namespace UtfUnknown.Tests
             byte[] buf = { 0x00, 0x00, 0xFF, 0xFE, 0x00, 0x65 };
 
             var result = CharsetDetector.DetectFromBytes(buf);
-            Assert.AreEqual(CodepageName.X_ISO_10646_UCS_4_2143, result.Detected.EncodingName);
+            Assert.AreEqual(CodepageName.X_ISO_10646_UCS_4_2143, result.Detected!.EncodingName);
             Assert.AreEqual(1.0f, result.Detected.Confidence);
         }
 
@@ -172,7 +172,7 @@ namespace UtfUnknown.Tests
         {
             byte[] buf = { 0xFF, 0xFE, };
             var result = CharsetDetector.DetectFromBytes(buf);
-            Assert.AreEqual(CodepageName.UTF16_LE, result.Detected.EncodingName);
+            Assert.AreEqual(CodepageName.UTF16_LE, result.Detected!.EncodingName);
             Assert.AreEqual(1.0f, result.Detected.Confidence);
         }
         
@@ -181,7 +181,7 @@ namespace UtfUnknown.Tests
         {
             byte[] buf = { 0xFF, 0xFE, 0x68, 0x00, 0x65, 0x00 };
             var result = CharsetDetector.DetectFromBytes(buf);
-            Assert.AreEqual(CodepageName.UTF16_LE, result.Detected.EncodingName);
+            Assert.AreEqual(CodepageName.UTF16_LE, result.Detected!.EncodingName);
             Assert.AreEqual(1.0f, result.Detected.Confidence);
         }
 
@@ -190,7 +190,7 @@ namespace UtfUnknown.Tests
         {
             byte[] buf = { 0x00, 0x00, 0xFE, 0xFF, 0x00, 0x00, 0x00, 0x68 };
             var result = CharsetDetector.DetectFromBytes(buf);
-            Assert.AreEqual(CodepageName.UTF32_BE, result.Detected.EncodingName);
+            Assert.AreEqual(CodepageName.UTF32_BE, result.Detected!.EncodingName);
             Assert.AreEqual(1.0f, result.Detected.Confidence);
         }
 
@@ -199,7 +199,7 @@ namespace UtfUnknown.Tests
         {
             byte[] buf = { 0xFF, 0xFE, 0x00, 0x00, 0x68, 0x00, 0x00, 0x00 };
             var result = CharsetDetector.DetectFromBytes(buf);
-            Assert.AreEqual(CodepageName.UTF32_LE, result.Detected.EncodingName);
+            Assert.AreEqual(CodepageName.UTF32_LE, result.Detected!.EncodingName);
             Assert.AreEqual(1.0f, result.Detected.Confidence);
         }
 
@@ -208,7 +208,7 @@ namespace UtfUnknown.Tests
         {
             byte[] buf = Encoding.UTF8.GetBytes("3");
             var result = CharsetDetector.DetectFromBytes(buf);
-            Assert.AreEqual(CodepageName.ASCII, result.Detected.EncodingName);
+            Assert.AreEqual(CodepageName.ASCII, result.Detected!.EncodingName);
             Assert.AreEqual(1.0f, result.Detected.Confidence);
         }
 
@@ -218,7 +218,7 @@ namespace UtfUnknown.Tests
 
             byte[] buf = Encoding.UTF8.GetBytes("3");
             var result = CharsetDetector.DetectFromBytes(buf);
-            Assert.AreEqual(CodepageName.ASCII, result.Detected.EncodingName);
+            Assert.AreEqual(CodepageName.ASCII, result.Detected!.EncodingName);
             Assert.AreEqual(1.0f, result.Detected.Confidence);
         }
 
@@ -228,7 +228,7 @@ namespace UtfUnknown.Tests
 
             byte[] buf = Encoding.UTF8.GetBytes("1234567890");
             var result = CharsetDetector.DetectFromBytes(buf);
-            Assert.AreEqual(CodepageName.ASCII, result.Detected.EncodingName);
+            Assert.AreEqual(CodepageName.ASCII, result.Detected!.EncodingName);
             Assert.AreEqual(1.0f, result.Detected.Confidence);
         }
 
@@ -237,7 +237,7 @@ namespace UtfUnknown.Tests
         {
             byte[] buf = Encoding.UTF8.GetBytes("3");
             var result = CharsetDetector.DetectFromBytes(buf);
-            Assert.AreEqual(CodepageName.ASCII, result.Detected.EncodingName);
+            Assert.AreEqual(CodepageName.ASCII, result.Detected!.EncodingName);
             Assert.AreEqual(1, result.Detected.Confidence);
         }
     }

--- a/tests/CharsetDetectorTestBatch.cs
+++ b/tests/CharsetDetectorTestBatch.cs
@@ -87,7 +87,7 @@ namespace UtfUnknown.Tests
             
             StringAssert.AreEqualIgnoringCase(
                 testCase.ExpectedEncoding,
-                detected.EncodingName,
+                detected!.EncodingName,
                 string.Concat(
                     $"Charset detection failed for {testCase.InputFile.FullName}. ",
                     $"Expected: {testCase.ExpectedEncoding}. ",
@@ -161,7 +161,7 @@ namespace UtfUnknown.Tests
             var detected = result.Detected;
 
             _logWriter.WriteLine($"- {file} ({expectedCharset}) -> {JsonConvert.SerializeObject(result, Formatting.Indented, new EncodingJsonConverter())}");
-            StringAssert.AreEqualIgnoringCase(expectedCharset, detected.EncodingName,
+            StringAssert.AreEqualIgnoringCase(expectedCharset, detected!.EncodingName,
                 $"Charset detection failed for {file}. Expected: {expectedCharset}, detected: {detected.EncodingName} ({detected.Confidence * 100.0f:0.00############}% confidence)");
             Assert.NotNull(detected.Encoding);
         }

--- a/tests/CodepageNameTest.cs
+++ b/tests/CodepageNameTest.cs
@@ -27,8 +27,8 @@ namespace UtfUnknown.Tests
         
         private static readonly IReadOnlyList<string> EncodingNames = typeof(CodepageName)
             .GetFields(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.CreateInstance)
-            .Select(x => x.GetValue(null).ToString())
-            .Where(x => !UnsupportedEncodings.Contains(x))
-            .ToList();
+            .Select(x => x.GetValue(null)?.ToString())
+            .Where(x => x != null && !UnsupportedEncodings.Contains(x))
+            .ToList()!;
     }
 }

--- a/tests/UTF-unknown.Tests.csproj
+++ b/tests/UTF-unknown.Tests.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>UtfUnknown.Tests</RootNamespace>
     <AssemblyName>UtfUnknown.Tests</AssemblyName>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\src\UtfUnknown.snk</AssemblyOriginatorKeyFile>
+    <Nullable>enable</Nullable>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hello!

Enable nullable reference types for main source code. It seems to be without breaking changes