### PR TITLE
Added chardet to NuGet package tags

### DIFF
--- a/src/UTF-unknown.csproj
+++ b/src/UTF-unknown.csproj
@@ -55,7 +55,7 @@ Features:
 
   <PropertyGroup>
 
-    <PackageTags>charset;detection;unicode;ascii;netstandard</PackageTags>
+    <PackageTags>charset;detection;unicode;ascii;netstandard;chardet</PackageTags>
     <PackageReleaseNotes>
 - See https://github.com/CharsetDetector/UTF-unknown/releases
     </PackageReleaseNotes>


### PR DESCRIPTION
Fixes https://github.com/CharsetDetector/UTF-unknown/issues/136