### PR TITLE
NuGet package move to PackageLicenseExpression (License unchanged)

### DIFF
--- a/src/UTF-unknown.csproj
+++ b/src/UTF-unknown.csproj
@@ -67,7 +67,7 @@ Features:
     <PackageIcon>logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/CharsetDetector/UTF-unknown</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/CharsetDetector/UTF-unknown/blob/master/license/MPL-1.1.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>MPL-1.1</PackageLicenseExpression> 
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/CharsetDetector/UTF-unknown</RepositoryUrl>
@@ -96,3 +96,4 @@ Features:
   </ItemGroup>
 
 </Project>
+

--- a/src/UTF-unknown.csproj
+++ b/src/UTF-unknown.csproj
@@ -67,7 +67,7 @@ Features:
     <PackageIcon>logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/CharsetDetector/UTF-unknown</PackageProjectUrl>
-    <PackageLicenseExpression>MPL-1.1</PackageLicenseExpression> 
+    <PackageLicenseExpression>MPL-1.1</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/CharsetDetector/UTF-unknown</RepositoryUrl>
@@ -96,4 +96,5 @@ Features:
   </ItemGroup>
 
 </Project>
+
 


### PR DESCRIPTION
MPL-1.1 is valid, see https://spdx.org/licenses/

<img width="806" height="24" alt="image" src="https://github.com/user-attachments/assets/c3be8b2a-233b-4f92-978e-44cb23704e58" />
